### PR TITLE
#132 Merge proxy with api-gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,18 @@
 FROM kong:0.10.4
 
 COPY gdl-run-kong.sh /gdl-run-kong.sh
+COPY nginx.tmpl /nginx.tmpl
+
 RUN chmod +x /gdl-run-kong.sh
 
 RUN yum --assumeyes install python-pip jq && \
  pip install awscli
+
+# ref https://github.com/Mashape/docker-kong/pull/84/files
+RUN mkdir -p /usr/local/kong/logs \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/access.log \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/admin_access.log \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/serf.log \
+    && ln -sf /tmp/logpipe /usr/local/kong/logs/error.log
 
 CMD ./gdl-run-kong.sh

--- a/gdl-run-kong.sh
+++ b/gdl-run-kong.sh
@@ -15,10 +15,25 @@ function prepare_remote {
     rm $secretsfile
 }
 
+function setup_logging {
+    ## Taken from pull request on docker-kong: https://github.com/Mashape/docker-kong/pull/84/files
+
+    # Make a pipe for the logs so we can ensure Kong logs get directed to docker logging
+    # see https://github.com/docker/docker/issues/6880
+    # also, https://github.com/docker/docker/issues/31106, https://github.com/docker/docker/issues/31243
+    # https://github.com/docker/docker/pull/16468, https://github.com/behance/docker-nginx/pull/51
+    rm -f /tmp/logpipe
+    mkfifo -m 666 /tmp/logpipe
+    # This child process will still receive signals as per https://github.com/Yelp/dumb-init#session-behavior
+    cat <> /tmp/logpipe 1>&2 &
+}
+
 if [ "$GDL_ENVIRONMENT" != "local" ]
 then
     prepare_remote
 fi
 
-export KONG_PROXY_LISTEN=0.0.0.0:80
-kong start
+setup_logging
+
+export KONG_PROXY_LISTEN=0.0.0.0:8000
+kong start --nginx-conf /nginx.tmpl

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -1,0 +1,90 @@
+worker_processes ${{NGINX_WORKER_PROCESSES}}; # can be set by kong.conf
+daemon ${{NGINX_DAEMON}};                     # can be set by kong.conf
+
+pid pids/nginx.pid;                           # this setting is mandatory
+error_log logs/error.log ${{LOG_LEVEL}};      # can be set by kong.conf
+
+events {
+  #worker_connections  1024;
+}
+
+http {
+  proxy_cache_path /tmp/nginx_cache_image levels=1:2 keys_zone=image_cache:10M max_size=100M inactive=40d;
+
+  # include default Kong Nginx config
+  include 'nginx-kong.conf';
+
+  # Port 79 brukes fra ELB port 80 for å hindre http (redirigere til https)
+  server {
+    listen 79;
+    return 301 https://$host$request_uri;
+  }
+
+  # Port 80 brukes fra ELB port 443
+  server {
+    listen 80;
+    charset UTF-8;
+
+    resolver 127.0.0.11;
+
+    set $images            'image-api.gdl-local';
+    set $api_gateway       '127.0.0.1:8000';
+
+    location ~* ^/image-api/(v.*)/raw/(.*) {
+
+    
+      set_by_lua_block $gdl_env { return os.getenv("GDL_ENVIRONMENT") }
+      set $s3_bucket        's3.eu-central-1.amazonaws.com/$gdl_env.images.gdl';
+      set $url_image        'http://$images/image-api/$1/raw/$2$is_args$args';
+
+      if ($args = '') {
+        set $url_image      'https://$s3_bucket/$2?';
+      }
+
+      proxy_set_header       Referer    'gdl_proxy';
+      proxy_pass             $url_image;
+
+      proxy_cache image_cache;
+      proxy_cache_key "$proxy_host$uri$is_args$args";
+      proxy_cache_valid 30d;
+      proxy_cache_lock on;
+      proxy_cache_use_stale error invalid_header timeout updating;
+      proxy_http_version 1.1;
+      expires 30d;
+    }
+
+    location ~* ^/reading-materials-api/epub/(.*) {
+      set_by_lua_block $gdl_env { return os.getenv("GDL_ENVIRONMENT") }
+      set $s3_bucket        's3.eu-central-1.amazonaws.com/$gdl_env.reading-materials.gdl';
+      set $url_epub         'https://$s3_bucket/epub/$1?';
+
+      proxy_set_header       Referer    'gdl_proxy';
+      proxy_pass             $url_epub;
+
+    }
+
+    location ~* ^/book-api/epub/(.*) {
+      set_by_lua_block $gdl_env { return os.getenv("GDL_ENVIRONMENT") }
+      set $s3_bucket        's3.eu-central-1.amazonaws.com/$gdl_env.books.gdl';
+      set $url_epub         'https://$s3_bucket/epub/$1?';
+
+      proxy_set_header       Referer    'gdl_proxy';
+      proxy_pass             $url_epub;
+
+    }
+
+    location ~* ^/health$ {
+        add_header 'Content-Length' 0;
+        return 200;
+    }
+
+    location ~* ^/([^/]*) {
+      proxy_set_header  Host $http_host;
+      proxy_set_header  X-Real-IP $remote_addr;
+      proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header  Forwarded "for=$remote_addr;proto=$http_x_forwarded_proto";
+      proxy_set_header  X-Forwarded-Prefix /$1;
+      proxy_pass http://$api_gateway;
+    }
+  }
+}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -31,8 +31,6 @@ http {
     set $api_gateway       '127.0.0.1:8000';
 
     location ~* ^/image-api/(v.*)/raw/(.*) {
-
-    
       set_by_lua_block $gdl_env { return os.getenv("GDL_ENVIRONMENT") }
       set $s3_bucket        's3.eu-central-1.amazonaws.com/$gdl_env.images.gdl';
       set $url_image        'http://$images/image-api/$1/raw/$2$is_args$args';
@@ -53,16 +51,6 @@ http {
       expires 30d;
     }
 
-    location ~* ^/reading-materials-api/epub/(.*) {
-      set_by_lua_block $gdl_env { return os.getenv("GDL_ENVIRONMENT") }
-      set $s3_bucket        's3.eu-central-1.amazonaws.com/$gdl_env.reading-materials.gdl';
-      set $url_epub         'https://$s3_bucket/epub/$1?';
-
-      proxy_set_header       Referer    'gdl_proxy';
-      proxy_pass             $url_epub;
-
-    }
-
     location ~* ^/book-api/epub/(.*) {
       set_by_lua_block $gdl_env { return os.getenv("GDL_ENVIRONMENT") }
       set $s3_bucket        's3.eu-central-1.amazonaws.com/$gdl_env.books.gdl';
@@ -70,7 +58,6 @@ http {
 
       proxy_set_header       Referer    'gdl_proxy';
       proxy_pass             $url_epub;
-
     }
 
     location ~* ^/health$ {


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#132

Combine apps proxy and api-gateway into one application. 

When deploying locally you must stop the old proxy application since both run port 80. In aws it can be deployed in parallell before terminating proxy. Changes in deploy-repo terminates the proxy servers so this application must be released before those changes are triggered.