### PR TITLE
#13 Redirect to https if http.

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -14,16 +14,14 @@ http {
   # include default Kong Nginx config
   include 'nginx-kong.conf';
 
-  # Port 79 brukes fra ELB port 80 for å hindre http (redirigere til https)
-  server {
-    listen 79;
-    return 301 https://$host$request_uri;
-  }
-
-  # Port 80 brukes fra ELB port 443
   server {
     listen 80;
     charset UTF-8;
+
+    # Redirect to https
+    if ($http_x_forwarded_proto != "https") {
+      return 301 https://$host$request_uri;
+    }
 
     gzip on;
     gzip_disable "msie6";


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#13
* Fjerna å lytte på port 79 til å kun lytte på port 80. Redirecter til https dersom requesten er http.